### PR TITLE
Xfade Filter

### DIFF
--- a/data.slideshow
+++ b/data.slideshow
@@ -7,7 +7,7 @@
     </audio>
     <image>MAT2-title.jpg</image>
     <timing start="0" duration="7000"/>
-    <transition duration="1000">crossfade</transition>
+    <transition duration="1000">fade</transition>
   </slide>
   <slide>
     <audio>
@@ -16,7 +16,7 @@
     <image>Mat-02-v01.jpg</image>
     <motion start="0.395 0 0.605 0.468" end="0 0 1 0.774"/>
     <timing start="3680" duration="10040"/>
-    <transition duration="1000">crossfade</transition>
+    <transition duration="1000">fade</transition>
   </slide>
   <slide>
     <audio>
@@ -25,7 +25,7 @@
     <image>Mat-02-v02.jpg</image>
     <motion start="0 0 1 0.774" end="0.378 0 0.622 0.484"/>
     <timing start="13720" duration="8080"/>
-    <transition duration="1000">crossfade</transition>
+    <transition duration="1000">fade</transition>
   </slide>
   <slide>
     <audio>

--- a/main.go
+++ b/main.go
@@ -116,8 +116,9 @@ func combine_xfade(Images []string, Transitions []string, TransitionDurations []
 
 	transition := Transitions[0]
 
-	if transition == "crossfade" {
+	if transition == "" {
 		transition = "fade"
+		transition_duration = 1000
 	}
 
 	fmt.Printf("Combining vieos temp%d.mp4 and temp%d.mp4\n", 0, 1)
@@ -140,49 +141,21 @@ func combine_xfade(Images []string, Transitions []string, TransitionDurations []
 
 		transition := Transitions[i]
 
-		if transition == "crossfade" {
+		if transition == "" {
 			transition = "fade"
-			fmt.Printf("Combining videos merged%d.mp4 and temp%d.mp4 with %s transition. \n", i, i+1, transition)
-			cmd := exec.Command("ffmpeg",
-				"-i", fmt.Sprintf("%s/output/merged%d.mp4", basePath, i),
-				"-i", fmt.Sprintf("%s/output/temp%d.mp4", basePath, i+1),
-				"-filter_complex", fmt.Sprintf("[0][1]xfade=transition=%s:duration=%dms:offset=%dms,format=yuv420p", transition, transition_duration, offset),
-				"-y", fmt.Sprintf("%s/output/merged%d.mp4", basePath, i+1),
-			)
-
-			output, err := cmd.CombinedOutput()
-			checkCMDError(output, err)
-		} else if transition == "" {
-			fmt.Printf("Combining videos merged%d.mp4 and temp%d.mp4 with no transition. \n", i, i+1)
-
-			//ffmpeg -i input1.mp4 -c copy -bsf:v h264_mp4toannexb -f mpegts intermediate1.ts
-			// ffmpeg -i input2.mp4 -c copy -bsf:v h264_mp4toannexb -f mpegts intermediate2.ts
-			// ffmpeg -i "concat:intermediate1.ts|intermediate2.ts" -c copy -bsf:a aac_adtstoasc output.mp4
-
-			cmd := exec.Command("ffmpeg",
-				"-i", fmt.Sprintf("%s/output/merged%d.mp4", basePath, i),
-				"-c", "copy", "-bsf:v", "h264_mp4toannexb", "-f", "mpegts", "-y", "intermediate1.ts",
-			)
-
-			output, err := cmd.CombinedOutput()
-			checkCMDError(output, err)
-
-			cmd = exec.Command("ffmpeg",
-				"-i", fmt.Sprintf("%s/output/temp%d.mp4", basePath, i+1),
-				"-c", "copy", "-bsf:v", "h264_mp4toannexb", "-f", "mpegts", "-y", "intermediate2.ts",
-			)
-
-			output, err = cmd.CombinedOutput()
-			checkCMDError(output, err)
-
-			cmd = exec.Command("ffmpeg",
-				"-i", "concat:intermediate1.ts|intermediate2.ts",
-				"-c", "copy", "-bsf:a", "aac_adtstoasc", "-y", fmt.Sprintf("%s/output/merged%d.mp4", basePath, i+1),
-			)
-
-			output, err = cmd.CombinedOutput()
-			checkCMDError(output, err)
+			transition_duration = 1000
 		}
+
+		fmt.Printf("Combining videos merged%d.mp4 and temp%d.mp4 with %s transition. \n", i, i+1, transition)
+		cmd := exec.Command("ffmpeg",
+			"-i", fmt.Sprintf("%s/output/merged%d.mp4", basePath, i),
+			"-i", fmt.Sprintf("%s/output/temp%d.mp4", basePath, i+1),
+			"-filter_complex", fmt.Sprintf("[0][1]xfade=transition=%s:duration=%dms:offset=%dms,format=yuv420p", transition, transition_duration, offset),
+			"-y", fmt.Sprintf("%s/output/merged%d.mp4", basePath, i+1),
+		)
+
+		output, err := cmd.CombinedOutput()
+		checkCMDError(output, err)
 	}
 }
 


### PR DESCRIPTION
The process:

1. Covert jpg to mp4 (no audio)
2. merge mp4 together with xfade
3. add narration on top of the video

Few attempts that did not work out:

1. I first tried doing the whole thing with a really long filter_complex that took images, audio, and converted to one video at the end with all the transitions in-between. The problem here was that ffmpeg couldn't find the stream specifier. This means that addBackgroundMusic() is not working anymore due to the same error. Maybe it's just me that's getting the error...?
2. I tried creating temporary mp4 files with the audio already engraved for each slice instead of adding the audio at the very end. The result is that there is no audio after the first xfade transition. I think this is because we need to add another filter_complex attribute for audio transitions which I am trying to figure out. I will continue to work on this to see if we can simplify the method. If so, then we don't have to worry about having the final video be too long. 

We will need to check whether the timing of the transition is correct with a "correct" video. I think we need to ask Chris to send us a sample made by their original method. 

But overall, xfade is working correctly!
