### PR TITLE
Combine videos in one single command, fix transition bugs, and match with new template

### DIFF
--- a/TemplateVideo/main.go
+++ b/TemplateVideo/main.go
@@ -335,7 +335,7 @@ func merge_videos_once(Images []string, Transitions []string, TransitionDuration
 		last_audio_output = next_audio_output
 	}
 
-	input_files = append(input_files, "-filter_complex", settb+video_fade_filter+audio_fade_filter, "-y", "../output/final.mp4")
+	input_files = append(input_files, "-filter_complex", settb+video_fade_filter+audio_fade_filter, "-y", "../output/empty_audio.mp4")
 
 	cmd := exec.Command("ffmpeg", input_files...)
 
@@ -348,7 +348,7 @@ func addAudio(Timings [][]string, Audios []string) {
 
 	audio_filter := ""
 	audio_last_filter := ""
-	audio_inputs = append(audio_inputs, "-y", "-i", "../output/final.mp4")
+	audio_inputs = append(audio_inputs, "-y", "-i", "../output/empty_audio.mp4")
 
 	for i := 0; i < len(Audios); i++ {
 		if Audios[i] != "" {
@@ -384,7 +384,7 @@ func addAudio(Timings [][]string, Audios []string) {
 		"-v", "error",
 		"-show_entries", "format=duration",
 		"-of", "default=noprint_wrappers=1:nokey=1",
-		fmt.Sprintf("../output/final.mp4"),
+		fmt.Sprintf("../output/empty_audio.mp4"),
 	)
 	output, err = cmd.CombinedOutput()
 	checkCMDError(output, err)


### PR DESCRIPTION
I figured out how to combine individual mp4 files in one single command. Even though this is not in parallel, it is much faster than our merge method (e.g. 25.3 seconds -> 11.5 seconds). Moreover, it is much simpler and easier to understand/debug.
Using this new method, I fixed the previous bug with credits page and the transition timings.

I also updated the code to run with the new updated slideshow file. This means that it doesn't use the start attribute of the <timing> tag, but rather calculates it based on previous slide information. 

I still need to add comments, but please take a look at it to make sure it's good.
I will also go ahead and delete the merge method.