### PR TITLE
Delete temporaries

### DIFF
--- a/TemplateVideo/eng Visit of the Magi -Mat 2.1-23.slideshow
+++ b/TemplateVideo/eng Visit of the Magi -Mat 2.1-23.slideshow
@@ -37,7 +37,7 @@
     <timing start="13720" duration="8080"/>
      <transition duration="1000">wiperight</transition>
   </slide>
-  <!--<slide>
+  <slide>
     <audio>
       <filename>narration-001.mp3</filename>
     </audio>
@@ -56,7 +56,7 @@
     <motion start="0 0 1 0.774" end="0.017 0.008 0.808 0.629"/>
     <timing start="27600" duration="25780"/>
   </slide>
-  <slide>
+  <!--<slide>
     <audio>
       <filename>narration-001.mp3</filename>
     </audio>

--- a/TemplateVideo/main.go
+++ b/TemplateVideo/main.go
@@ -79,12 +79,12 @@ func main() {
 		//allImages := []int{0, 1, 2, 3, 4, 5, 6}
 
 		mergeVideos(allImages, Images, Transitions, TransitionDurations, Timings, 0)
+		copyFinal()
 	} else {
 		combineVideos(Images, Transitions, TransitionDurations, Timings, Audios)
 		fmt.Println("Adding intro music...")
 		addBackgroundMusic(BackAudioPath, BackAudioVolume)
 	}
-
 	fmt.Println("Finished making video...")
 
 	if !*saveTemps { // If user did not specify the -s flag at runtime, delete the temporary videos
@@ -110,6 +110,13 @@ func checkCMDError(output []byte, err error) {
 	if err != nil {
 		log.Fatalln(fmt.Sprint(err) + ": " + string(output))
 	}
+}
+
+// Function to copy over the final video out of the main directory
+func copyFinal() {
+	cmd := exec.Command("ffmpeg", "-i", "./temp/merged0-0.mp4", "-y", "./final.mp4")
+	output, err := cmd.CombinedOutput()
+	checkCMDError(output, err)
 }
 
 /* Function to scale all the input images to a uniform height/width


### PR DESCRIPTION
Closes issue #51 Added functionality to delete the temporary videos generated during the production process, using the following logic:

1. Create temp folder in current directory
2. Create all temp and intermediate merge videos inside temp directory
3. Create final video outside temp directory in main folder
4. Remove temp directory at the end

I also added the "-s" flag to save temporary files which essentially skips step 4 when included 