### PR TITLE
Fix GitHub Action workdir

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,5 @@ jobs:
           distribution: goreleaser
           version: latest
           args: release --rm-dist
-          workdir: src
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Remove the workdir attribute on the action so that it used the root dir