### PR TITLE
Add more precision to floating point number in zoom parameters

### DIFF
--- a/src/ffmpeg/ffmpeg.go
+++ b/src/ffmpeg/ffmpeg.go
@@ -88,13 +88,13 @@ func MakeTempVideosWithoutAudio(Images []string, Timings []string, Audios []stri
 			// At the end of the goroutine, tell the WaitGroup
 			//   that another thread has completed.
 			defer wg.Done()
+			zoom_cmd := CreateZoomCommand(Motions[i], helper.ConvertStringToFloat(duration)[0])
 			if v {
-				fmt.Println(fmt.Sprintf("Making temp%d-%d.mp4 video with:\n	Image: %s\n	Duration: %s ms\n	Start Rectangle (x, y, height width): %f\n	End Rectangle (x, y, height width): %f\n",
-					i+1, totalNumImages, Images[i], duration, Motions[i][0], Motions[i][1]))
+				fmt.Println(fmt.Sprintf("Making temp%d-%d.mp4 video with:\n	Image: %s\n	Duration: %s ms\n	Start Rectangle (left, top, width, height): %f\n	End Rectangle (left, top, width, height): %f\n	Zoom Cmd: %s\n",
+					i+1, totalNumImages, Images[i], duration, Motions[i][0], Motions[i][1], zoom_cmd))
 			} else {
 				fmt.Println(fmt.Sprintf("Making temp%d-%d.mp4 video", i+1, totalNumImages))
 			}
-			zoom_cmd := CreateZoomCommand(Motions[i], helper.ConvertStringToFloat(duration)[0])
 
 			cmd := CmdCreateTempVideo(Images[i], duration, zoom_cmd, fmt.Sprintf(tempPath+"/temp%d-%d.mp4", i, totalNumImages))
 			output, err := cmd.CombinedOutput()

--- a/src/ffmpeg/ffmpeg_local.go
+++ b/src/ffmpeg/ffmpeg_local.go
@@ -120,9 +120,9 @@ func CreateZoomCommand(Motions [][]float64, TimingDuration float64) string {
 	var y_change float64 = y_end - y_init
 	var y_incr float64 = y_change / float64(num_frames)
 
-	zoom_cmd := fmt.Sprintf("1/((%.3f)%s(%.3f)*on)", size_init-size_incr, checkSign(size_incr), math.Abs(size_incr))
-	x_cmd := fmt.Sprintf("%0.3f*iw%s%0.3f*iw*on", x_init-x_incr, checkSign(x_incr), math.Abs(x_incr))
-	y_cmd := fmt.Sprintf("%0.3f*ih%s%0.3f*ih*on", y_init-y_incr, checkSign(y_incr), math.Abs(y_incr))
+	zoom_cmd := fmt.Sprintf("1/((%.6f)%s(%.6f)*on)", size_init-size_incr, checkSign(size_incr), math.Abs(size_incr))
+	x_cmd := fmt.Sprintf("%0.6f*iw%s%0.6f*iw*on", x_init-x_incr, checkSign(x_incr), math.Abs(x_incr))
+	y_cmd := fmt.Sprintf("%0.6f*ih%s%0.6f*ih*on", y_init-y_incr, checkSign(y_incr), math.Abs(y_incr))
 	final_cmd := fmt.Sprintf("scale=8000:-1,zoompan=z='%s':x='%s':y='%s':d=%d:fps=25,scale=1280:720,setsar=1:1", zoom_cmd, x_cmd, y_cmd, num_frames)
 
 	return final_cmd


### PR DESCRIPTION
The zoompan is not quite right due to rounding errors.  Extending the precision of the numbers passed to FFmpeg fixes the zoompan.

The original Python code used `%0.10f` for the format and when converted to Go it was changed to `%0.3f`.  This doesn't not provide enough precision since the width is divided by number of frames.