### PR TITLE
Fix audio missing from the last slide

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func main() {
 	start := time.Now()
 
 	// Parse in the various pieces from the template
-	slideshow := slideshow.NewSlideshow(optionFlags.SlideshowDirectory, optionFlags.Verbose)
+	slideshow := slideshow.NewSlideshow(optionFlags.SlideshowDirectory, optionFlags.Verbose, tempDirectory)
 
 	fmt.Println("Scaling images...")
 	slideshow.ScaleImages(optionFlags.LowQuality)

--- a/src/ffmpeg/ffmpeg.go
+++ b/src/ffmpeg/ffmpeg.go
@@ -285,7 +285,7 @@ func AddAudio(Timings []string, Audios []string, tempPath string, v bool) {
 			totalDuration := 0.0
 
 			for j := 0; j < i; j++ {
-				if Audios[i] == Audios[j] {
+				if Audios[i] == Audios[j] || Audios[j] == tempPath+"/mergedAudio.mp3" {
 					transition_duration, err := strconv.ParseFloat(strings.TrimSpace(Timings[j]), 8)
 					helper.Check(err)
 					transition_duration = transition_duration / 1000

--- a/src/ffmpeg/ffmpeg.go
+++ b/src/ffmpeg/ffmpeg.go
@@ -68,7 +68,7 @@ func compareVersion(version string) string {
  *		tempPath - Filepath to the temporary directory to store each temp video
  *		v - verbose flag to determine what feedback to print
  */
-func MakeTempVideosWithoutAudio(Images []string, Timings []string, Audios []string, Motions [][][]float64, tempPath string, v bool) {
+func MakeTempVideosWithoutAudio(Images []string, Timings []string, Audios [][]string, Motions [][][]float64, tempPath string, v bool) {
 	fmt.Println("Making temporary videos in parallel...")
 	totalNumImages := len(Images)
 
@@ -270,7 +270,7 @@ func MergeTempVideosOldFade(Images []string, TransitionDurations []string, Timin
  *		tempPath - path to the temp folder where the audioless video is stored
  *		v - verbose flag to determine what feedback to print
  */
-func AddAudio(Timings []string, Audios []string, tempPath string, v bool) {
+func AddAudio(Timings []string, Audios [][]string, tempPath string, v bool) {
 	fmt.Println("Adding audio...")
 	audio_inputs := []string{}
 
@@ -279,7 +279,14 @@ func AddAudio(Timings []string, Audios []string, tempPath string, v bool) {
 
 	audio_inputs = append(audio_inputs, "-y", "-i", tempPath+"/video_with_no_audio.mp4")
 
+	mergedAudio := false
+
 	for i := 0; i < len(Audios); i++ {
+		if Audios[i][0] != "" && Audios[i][1] != "" {
+			MergeAudios(Audios[i][1], Audios[i][1], Timings[i-1], Timings[i], tempPath)
+			mergedAudio = true
+		}
+
 		if Audios[i] != "" {
 			audio_inputs = append(audio_inputs, "-i", Audios[i])
 			totalDuration := 0.0
@@ -316,6 +323,14 @@ func AddAudio(Timings []string, Audios []string, tempPath string, v bool) {
 	CheckCMDError(output, err)
 
 	trimEnd(tempPath)
+}
+
+func MergeAudios(backgroundMusicDir string, narrationAudioDir string, startTime string, duration string, tempPath string) {
+	cmd := exec.Command("ffmpeg", "-i", backgroundMusicDir, "-i", narrationAudioDir, "-filter_complex",
+		fmt.Sprintf("[0:a]atrim=start=%s:duration=%s[a1];[1:a]atrim=start=0:duration=%ss,asetpts=expr=PTS+0[a2];[a1][a2]amix=inputs=2[a]", startTime, duration, duration),
+		"-map", "[a]", "-c:v", "copy", "-y", tempPath+"/mergedAudio.mp3")
+	output, err := cmd.CombinedOutput()
+	CheckCMDError(output, err)
 }
 
 /* Function to copy the final video from the temp folder to the output location specified

--- a/src/slideshow/slideshow.go
+++ b/src/slideshow/slideshow.go
@@ -22,7 +22,7 @@ import (
  */
 type slideshow struct {
 	images              []string
-	audios              []string
+	audios              [][]string
 	transitions         []string
 	transitionDurations []string
 	timings             []string
@@ -43,7 +43,7 @@ func NewSlideshow(slideshowDirectory string, v bool) slideshow {
 	slideshow_template := readSlideshowXML(slideshowDirectory)
 
 	Images := []string{}
-	Audios := []string{}
+	Audios := [][]string{}
 	Transitions := []string{}
 	TransitionDurations := []string{}
 	Timings := []string{}
@@ -55,12 +55,16 @@ func NewSlideshow(slideshowDirectory string, v bool) slideshow {
 
 	for _, slide := range slideshow_template.Slide {
 		if slide.Audio.Background_Filename.Path != "" { // Intro music is stored differently in the xml
-			Audios = append(Audios, templateDir+slide.Audio.Background_Filename.Path)
-		} else {
-			if slide.Audio.Filename.Name == "" {
-				Audios = append(Audios, "")
+			if slide.Audio.Filename.Name != "" {
+				Audios = append(Audios, []string{templateDir + slide.Audio.Background_Filename.Path, templateDir + slide.Audio.Filename.Name})
 			} else {
-				Audios = append(Audios, templateDir+slide.Audio.Filename.Name)
+				Audios = append(Audios, []string{templateDir + slide.Audio.Background_Filename.Path, ""})
+			}
+		} else {
+			if slide.Audio.Filename.Name != "" {
+				Audios = append(Audios, []string{"", templateDir + slide.Audio.Filename.Name})
+			} else {
+				Audios = append(Audios, []string{"", ""})
 			}
 		}
 		Images = append(Images, templateDir+slide.Image.Name)

--- a/src/slideshow/slideshow.go
+++ b/src/slideshow/slideshow.go
@@ -22,7 +22,7 @@ import (
  */
 type slideshow struct {
 	images              []string
-	audios              [][]string
+	audios              []string
 	transitions         []string
 	transitionDurations []string
 	timings             []string
@@ -39,11 +39,11 @@ type slideshow struct {
  * Returns:
  *			slideshow - the filled slideshow structure, containing all the data parsed
  */
-func NewSlideshow(slideshowDirectory string, v bool) slideshow {
+func NewSlideshow(slideshowDirectory string, v bool, tempPath string) slideshow {
 	slideshow_template := readSlideshowXML(slideshowDirectory)
 
 	Images := []string{}
-	Audios := [][]string{}
+	Audios := []string{}
 	Transitions := []string{}
 	TransitionDurations := []string{}
 	Timings := []string{}
@@ -53,18 +53,20 @@ func NewSlideshow(slideshowDirectory string, v bool) slideshow {
 
 	templateDir, template_name := splitFileNameFromDirectory(slideshowDirectory)
 
-	for _, slide := range slideshow_template.Slide {
+	for i, slide := range slideshow_template.Slide {
+		Timings = append(Timings, slide.Timing.Duration)
 		if slide.Audio.Background_Filename.Path != "" { // Intro music is stored differently in the xml
 			if slide.Audio.Filename.Name != "" {
-				Audios = append(Audios, []string{templateDir + slide.Audio.Background_Filename.Path, templateDir + slide.Audio.Filename.Name})
+				FFmpeg.MergeAudios(templateDir+slide.Audio.Background_Filename.Path, templateDir+slide.Audio.Filename.Name, Timings[i-1], Timings[i], tempPath)
+				Audios = append(Audios, tempPath+"/mergedAudio.mp3")
 			} else {
-				Audios = append(Audios, []string{templateDir + slide.Audio.Background_Filename.Path, ""})
+				Audios = append(Audios, templateDir+slide.Audio.Background_Filename.Path)
 			}
 		} else {
 			if slide.Audio.Filename.Name != "" {
-				Audios = append(Audios, []string{"", templateDir + slide.Audio.Filename.Name})
+				Audios = append(Audios, templateDir+slide.Audio.Filename.Name)
 			} else {
-				Audios = append(Audios, []string{"", ""})
+				Audios = append(Audios, "")
 			}
 		}
 		Images = append(Images, templateDir+slide.Image.Name)
@@ -85,7 +87,6 @@ func NewSlideshow(slideshowDirectory string, v bool) slideshow {
 			motions = [][]float64{helper.ConvertStringToFloat(slide.Motion.Start), helper.ConvertStringToFloat(slide.Motion.End)}
 		}
 		Motions = append(Motions, motions)
-		Timings = append(Timings, slide.Timing.Duration)
 	}
 
 	if v {

--- a/src/slideshow/slideshow_test.go
+++ b/src/slideshow/slideshow_test.go
@@ -8,7 +8,7 @@ import (
 func TestReadSlideshow(t *testing.T) {
 	templateName := "../../TestInput/test.slideshow"
 
-	slideshow := NewSlideshow(templateName, false)
+	slideshow := NewSlideshow(templateName, false, "../../TestInput")
 
 	expectedImages := []string{"../../TestInput/Jn01.1-18-title.jpg", "../../TestInput/./VB-John 1v1.jpg", "../../TestInput/./VB-John 1v3.jpg", "../../TestInput/./VB-John 1v4.jpg", "../../TestInput/./VB-John 1v5a.jpg",
 		"../../TestInput/./VB-John 1v5b.jpg", "../../TestInput/./VB-John 1v6.jpg", "../../TestInput/Gospel of John-credits.jpg"}


### PR DESCRIPTION
Added new method called MergeAudio which takes two audio files and merge them into one based on timing durations
With this method, the background music and the narration audio can be merged together and saved as a temporary audio.

This temporary audio is used when overlaying the audio to the video. 